### PR TITLE
Disable step parameters of type 'result' in the pipeline editor

### DIFF
--- a/src/app/pipelines/components/pipeline-parameter/pipeline-parameter.component.html
+++ b/src/app/pipelines/components/pipeline-parameter/pipeline-parameter.component.html
@@ -23,7 +23,8 @@
         *ngIf="
           parameterType === 'step' ||
             parameterType === 'secondary' ||
-            parameterType === 'pipeline';
+            parameterType === 'pipeline' ||
+            parameterType === 'result';
           else isNotTypeResponse
         "
       >
@@ -80,7 +81,11 @@
         <mat-form-field>
           <input
             matInput
-            *ngIf="parameterType !== 'step' || parameterType !== 'secondary'"
+            *ngIf="
+              parameterType !== 'step' ||
+              parameterType !== 'secondary' ||
+              parameterType !== 'result'
+            "
             [(ngModel)]="param.value"
             (change)="handleChange(param.id, param)"
           />
@@ -138,12 +143,12 @@
           >Script</mat-option
         >
         <mat-option
-          *ngIf="!stepGroup.enabled && parameters.length === 1"
+          *ngIf="!stepGroup.enabled && parameters.length === 1 && isABranchStep"
           value="result"
           >Result</mat-option
         >
         <mat-option
-          *ngIf="isAnObjectParameter && parameters.length === 1; s"
+          *ngIf="isAnObjectParameter && parameters.length === 1"
           value="object"
           >Object</mat-option
         >

--- a/src/app/pipelines/components/pipeline-parameter/pipeline-parameter.component.ts
+++ b/src/app/pipelines/components/pipeline-parameter/pipeline-parameter.component.ts
@@ -51,6 +51,7 @@ export class PipelineParameterComponent implements OnInit {
   @Input() stepSuggestions: string[];
   @Input() packageObjects: PackageObject[];
   @Input() pipelines: Pipeline[];
+  @Input() isABranchStep: boolean;
   @Input() stepGroup: StepGroupProperty = { enabled: false };
   @Input()
   set stepParameters(stepParameter: PipelineStepParam) {

--- a/src/app/pipelines/components/pipelines-editor/pipelines-editor.component.html
+++ b/src/app/pipelines/components/pipelines-editor/pipelines-editor.component.html
@@ -149,6 +149,7 @@
                 <mat-accordion>
                   <app-pipelines-parameter
                     *ngFor="let param of selectedStep.params"
+                    [isABranchStep]="isABranchStep"
                     [stepType]="selectedStep.type"
                     [stepParameters]="param"
                     [stepGroup]="stepGroup"

--- a/src/app/pipelines/components/pipelines-editor/pipelines-editor.component.ts
+++ b/src/app/pipelines/components/pipelines-editor/pipelines-editor.component.ts
@@ -50,6 +50,7 @@ export class PipelinesEditorComponent implements OnInit {
   designerModel: DesignerModel = DesignerComponent.newModel();
   stepCreated$: Subject<PipelineStep> = new Subject<PipelineStep>();
   dndSubject: Subject<DesignerElement> = new Subject<DesignerElement>();
+  isABranchStep: boolean;
   stepLookup = {};
   typeAhead: string[] = [];
   pipelineValidator;
@@ -194,6 +195,9 @@ export class PipelinesEditorComponent implements OnInit {
       parameterType: undefined,
     };
     this.selectedStep.params.unshift(executeIfEmpty);
+    this.selectedStep.type === 'branch'
+      ? (this.isABranchStep = true)
+      : (this.isABranchStep = false);
   }
 
   /**


### PR DESCRIPTION
-Enabled Result option only for branch steps.
-Hide input when the parameter type is result.