### PR TITLE
- Fixed wasted whitespace in steps category

### DIFF
--- a/src/app/steps/components/selector/steps-category/steps-category.component.scss
+++ b/src/app/steps/components/selector/steps-category/steps-category.component.scss
@@ -5,7 +5,7 @@
 }
 
 .step-list {
-  height: 350px;
+  max-height: 350px;
 }
 
 .mat-card {


### PR DESCRIPTION
Will still show scrollbar for longer step categories, but will properly truncate smaller ones. Tested in Chrome and Firefox 

![image](https://user-images.githubusercontent.com/17391383/82090548-68d40e80-96bb-11ea-9063-fc337b1d159c.png)
